### PR TITLE
Added Bootstrap Modals for Uploading Dataset and Model in Dashboard2

### DIFF
--- a/frontend/src/pages/DashboardPage/ControlButtons/ControlButtons.jsx
+++ b/frontend/src/pages/DashboardPage/ControlButtons/ControlButtons.jsx
@@ -190,8 +190,8 @@ const ControlButtons = ({ onDownload }) => {
 
         {/* Bootstrap Modal for model upload instructions */}
         {showModal && (
-            <div className="modal show" style={{ display: "block" }}>
-              <div className="modal-dialog">
+            <div className="modal show" style={{ display: "block", backdropFilter: "blur(5px)" }}>
+              <div className="modal-dialog modal-dialog-centered">
                 <div className="modal-content">
                   <div className="modal-header">
                     <h5 className="modal-title">Model Upload Instructions</h5>
@@ -201,9 +201,9 @@ const ControlButtons = ({ onDownload }) => {
                         style={{
                           backgroundColor: "#45a049",
                           borderColor: "#45a049",
-                          fontSize: "0.875rem",  // Smaller font size
-                          padding: "0.25rem 0.5rem",  // Smaller padding
-                          borderRadius: "0.2rem"  // Optional: round corners slightly
+                          fontSize: "0.875rem",
+                          padding: "0.25rem 0.5rem",
+                          borderRadius: "0.2rem",
                         }}
                         onClick={closeModal}
                     >
@@ -211,8 +211,9 @@ const ControlButtons = ({ onDownload }) => {
                     </button>
                   </div>
                   <div className="modal-body">
-                    <p><strong>File format:</strong> The file must be in <code>.pkl</code> format.</p>
-                    <p><strong>File size:</strong> The file size must be less than 1 MB.</p>
+                    <p>
+                      <strong>File format:</strong> The file must be in <code>.pkl</code> format.
+                    </p>
                   </div>
                   <div className="modal-footer">
                     <button
@@ -221,29 +222,27 @@ const ControlButtons = ({ onDownload }) => {
                         style={{
                           backgroundColor: "#45a049",
                           borderColor: "#45a049",
-                          fontSize: "0.875rem",  // Smaller font size
-                          padding: "0.25rem 0.5rem",  // Smaller padding
-                          borderRadius: "0.2rem"  // Optional: round corners slightly
+                          fontSize: "0.875rem",
+                          padding: "0.25rem 0.5rem",
+                          borderRadius: "0.2rem",
                         }}
                         onClick={() => {
-                          fileInputRef1.current.click();  // Trigger file input inside modal
+                          fileInputRef1.current.click(); // Trigger file input inside modal
                           closeModal(); // Close the modal after triggering file input
                         }}
                     >
                       Upload Model
                     </button>
-
-
-
                   </div>
                 </div>
               </div>
             </div>
         )}
 
+
         {showModaldataset && (
-            <div className="modal show" style={{ display: "block" }}>
-              <div className="modal-dialog">
+            <div className="modal show" style={{ display: "block", backdropFilter: "blur(5px)" }}>
+              <div className="modal-dialog modal-dialog-centered">
                 <div className="modal-content">
                   <div className="modal-header">
                     <h5 className="modal-title">Dataset Upload Instructions</h5>
@@ -253,9 +252,9 @@ const ControlButtons = ({ onDownload }) => {
                         style={{
                           backgroundColor: "#45a049",
                           borderColor: "#45a049",
-                          fontSize: "0.875rem",  // Smaller font size
-                          padding: "0.25rem 0.5rem",  // Smaller padding
-                          borderRadius: "0.2rem"  // Optional: round corners slightly
+                          fontSize: "0.875rem",
+                          padding: "0.25rem 0.5rem",
+                          borderRadius: "0.2rem",
                         }}
                         onClick={closeModal2}
                     >
@@ -263,7 +262,9 @@ const ControlButtons = ({ onDownload }) => {
                     </button>
                   </div>
                   <div className="modal-body">
-                    <p><strong>File format:</strong> The file must be in <code>.csv</code> format.</p>
+                    <p>
+                      <strong>File format:</strong> The file must be in <code>.csv</code> format.
+                    </p>
                   </div>
                   <div className="modal-footer">
                     <button
@@ -272,25 +273,23 @@ const ControlButtons = ({ onDownload }) => {
                         style={{
                           backgroundColor: "#45a049",
                           borderColor: "#45a049",
-                          fontSize: "0.875rem",  // Smaller font size
-                          padding: "0.25rem 0.5rem",  // Smaller padding
-                          borderRadius: "0.2rem"  // Optional: round corners slightly
+                          fontSize: "0.875rem",
+                          padding: "0.25rem 0.5rem",
+                          borderRadius: "0.2rem",
                         }}
                         onClick={() => {
-                          fileInputRef2.current.click();;  // Trigger file input inside modal
+                          fileInputRef2.current.click(); // Trigger file input inside modal
                           closeModal2(); // Close the modal after triggering file input
                         }}
                     >
                       Upload Dataset
                     </button>
-
-
-
                   </div>
                 </div>
               </div>
             </div>
         )}
+
 
 
       </div>

--- a/frontend/src/pages/DashboardPage/ControlButtons/ControlButtons.jsx
+++ b/frontend/src/pages/DashboardPage/ControlButtons/ControlButtons.jsx
@@ -7,6 +7,7 @@ const ControlButtons = ({ onDownload }) => {
 
   const [currUser, setCurrUser] = useState("");
   const [showModal, setShowModal] = useState(false); // Modal visibility state
+  const [showModaldataset, setshowModaldataset] = useState(false);
 
   const fileInputRef1 = useRef(null); // For model import
   const fileInputRef2 = useRef(null); // For dataset import
@@ -62,7 +63,7 @@ const ControlButtons = ({ onDownload }) => {
   };
 
   const handleImportDataset = () => {
-    fileInputRef2.current.click();
+    setshowModaldataset(true);
   };
 
   const handleModelFileChange = async (event) => {
@@ -145,7 +146,12 @@ const ControlButtons = ({ onDownload }) => {
 
   const closeModal = () => {
     setShowModal(false); // Close the modal
+
   };
+  const closeModal2 = () => {
+    setshowModaldataset(false) // Close the modal
+  };
+
 
   return (
       <div className="file-import-container">
@@ -226,9 +232,24 @@ const ControlButtons = ({ onDownload }) => {
                     >
                       Upload Model
                     </button>
+
+
+
+                  </div>
+                </div>
+              </div>
+            </div>
+        )}
+
+        {showModaldataset && (
+            <div className="modal show" style={{ display: "block" }}>
+              <div className="modal-dialog">
+                <div className="modal-content">
+                  <div className="modal-header">
+                    <h5 className="modal-title">Dataset Upload Instructions</h5>
                     <button
                         type="button"
-                        className="btn btn-secondary"
+                        className="close"
                         style={{
                           backgroundColor: "#45a049",
                           borderColor: "#45a049",
@@ -236,10 +257,35 @@ const ControlButtons = ({ onDownload }) => {
                           padding: "0.25rem 0.5rem",  // Smaller padding
                           borderRadius: "0.2rem"  // Optional: round corners slightly
                         }}
-                        onClick={closeModal}
+                        onClick={closeModal2}
                     >
-                      Close
+                      &times;
                     </button>
+                  </div>
+                  <div className="modal-body">
+                    <p><strong>File format:</strong> The file must be in <code>.csv</code> format.</p>
+                  </div>
+                  <div className="modal-footer">
+                    <button
+                        type="button"
+                        className="btn btn-primary"
+                        style={{
+                          backgroundColor: "#45a049",
+                          borderColor: "#45a049",
+                          fontSize: "0.875rem",  // Smaller font size
+                          padding: "0.25rem 0.5rem",  // Smaller padding
+                          borderRadius: "0.2rem"  // Optional: round corners slightly
+                        }}
+                        onClick={() => {
+                          fileInputRef2.current.click();;  // Trigger file input inside modal
+                          closeModal2(); // Close the modal after triggering file input
+                        }}
+                    >
+                      Upload Dataset
+                    </button>
+
+
+
                   </div>
                 </div>
               </div>

--- a/frontend/src/pages/ModelTester/ControlButtons2/ControlButtons2.jsx
+++ b/frontend/src/pages/ModelTester/ControlButtons2/ControlButtons2.jsx
@@ -220,8 +220,8 @@ const ControlButton2 = ({ setUploadedFiles }) => {
             )}
 
             {showModal && (
-                <div className="modal show" style={{ display: "block" }}>
-                    <div className="modal-dialog">
+                <div className="modal show" style={{ display: "block", backdropFilter: "blur(5px)" }}>
+                    <div className="modal-dialog modal-dialog-centered">
                         <div className="modal-content">
                             <div className="modal-header">
                                 <h5 className="modal-title">Model Upload Instructions</h5>
@@ -231,9 +231,9 @@ const ControlButton2 = ({ setUploadedFiles }) => {
                                     style={{
                                         backgroundColor: "#45a049",
                                         borderColor: "#45a049",
-                                        fontSize: "0.875rem",  // Smaller font size
-                                        padding: "0.25rem 0.5rem",  // Smaller padding
-                                        borderRadius: "0.2rem"  // Optional: round corners slightly
+                                        fontSize: "0.875rem",
+                                        padding: "0.25rem 0.5rem",
+                                        borderRadius: "0.2rem",
                                     }}
                                     onClick={closeModal}
                                 >
@@ -241,8 +241,13 @@ const ControlButton2 = ({ setUploadedFiles }) => {
                                 </button>
                             </div>
                             <div className="modal-body">
-                                <p><strong>File format:</strong> The file must be in <code>.pkl</code> format.</p>
-                                <p><strong>File size:</strong> The file size must be less than 1 MB.</p>
+                                <p>
+                                    <strong>File format:</strong> The file must be in <code>.pkl</code> format.
+                                </p>
+
+                                <p>
+                                    <strong>Important:</strong> The model name should not be <code>model.pkl</code>. Avoid uploading models with the same name as existing ones to prevent conflicts.
+                                </p>
                             </div>
                             <div className="modal-footer">
                                 <button
@@ -251,25 +256,23 @@ const ControlButton2 = ({ setUploadedFiles }) => {
                                     style={{
                                         backgroundColor: "#45a049",
                                         borderColor: "#45a049",
-                                        fontSize: "0.875rem",  // Smaller font size
-                                        padding: "0.25rem 0.5rem",  // Smaller padding
-                                        borderRadius: "0.2rem"  // Optional: round corners slightly
+                                        fontSize: "0.875rem",
+                                        padding: "0.25rem 0.5rem",
+                                        borderRadius: "0.2rem",
                                     }}
                                     onClick={() => {
-                                        fileInputRef.current.click();  // Trigger file input inside modal
+                                        fileInputRef.current.click(); // Trigger file input inside modal
                                         closeModal(); // Close the modal after triggering file input
                                     }}
                                 >
                                     Upload Model
                                 </button>
-
-
-
                             </div>
                         </div>
                     </div>
                 </div>
             )}
+
         </div>
     );
 };

--- a/frontend/src/pages/ModelTester/ControlButtons2/ControlButtons2.jsx
+++ b/frontend/src/pages/ModelTester/ControlButtons2/ControlButtons2.jsx
@@ -6,6 +6,7 @@ const ControlButton2 = ({ setUploadedFiles }) => {
 
     const [currUser, setCurrUser] = useState(""); // Store current user's email
     const [uploadedFiles, setUploadedFilesState] = useState([]); // Local state for uploaded files
+    const [showModal, setShowModal] = useState(false); // Modal visibility state
     const fileInputRef = useRef(null); // For model import
 
     // Fetch email for the current user
@@ -62,7 +63,13 @@ const ControlButton2 = ({ setUploadedFiles }) => {
     }, []);
 
     const handleModelUploadClick = () => {
-        fileInputRef.current.click(); // Trigger model file input
+        setShowModal(true);
+         // Trigger model file input
+    };
+
+    const closeModal = () => {
+        setShowModal(false); // Close the modal
+
     };
 
     const handleModelFileChange = async (event) => {
@@ -209,6 +216,58 @@ const ControlButton2 = ({ setUploadedFiles }) => {
                             </li>
                         ))}
                     </ul>
+                </div>
+            )}
+
+            {showModal && (
+                <div className="modal show" style={{ display: "block" }}>
+                    <div className="modal-dialog">
+                        <div className="modal-content">
+                            <div className="modal-header">
+                                <h5 className="modal-title">Model Upload Instructions</h5>
+                                <button
+                                    type="button"
+                                    className="close"
+                                    style={{
+                                        backgroundColor: "#45a049",
+                                        borderColor: "#45a049",
+                                        fontSize: "0.875rem",  // Smaller font size
+                                        padding: "0.25rem 0.5rem",  // Smaller padding
+                                        borderRadius: "0.2rem"  // Optional: round corners slightly
+                                    }}
+                                    onClick={closeModal}
+                                >
+                                    &times;
+                                </button>
+                            </div>
+                            <div className="modal-body">
+                                <p><strong>File format:</strong> The file must be in <code>.pkl</code> format.</p>
+                                <p><strong>File size:</strong> The file size must be less than 1 MB.</p>
+                            </div>
+                            <div className="modal-footer">
+                                <button
+                                    type="button"
+                                    className="btn btn-primary"
+                                    style={{
+                                        backgroundColor: "#45a049",
+                                        borderColor: "#45a049",
+                                        fontSize: "0.875rem",  // Smaller font size
+                                        padding: "0.25rem 0.5rem",  // Smaller padding
+                                        borderRadius: "0.2rem"  // Optional: round corners slightly
+                                    }}
+                                    onClick={() => {
+                                        fileInputRef.current.click();  // Trigger file input inside modal
+                                        closeModal(); // Close the modal after triggering file input
+                                    }}
+                                >
+                                    Upload Model
+                                </button>
+
+
+
+                            </div>
+                        </div>
+                    </div>
                 </div>
             )}
         </div>


### PR DESCRIPTION
## 📜 Description

This pull request implements a **Bootstrap Modal** feature for the model upload instructions in the Dashboard. The modal provides clear guidelines for users to upload models in the correct format and size, enhancing user experience and ensuring smoother interactions.

---

## ✅ Changes Made

- Added a **Bootstrap Modal** to the Dashboard for displaying upload instructions.
- Included details about:
  - **File Format**: `.pkl` files only.
  - **File Size**: Less than 1 MB.
- Integrated buttons in the modal for:
  - **Upload Model**: Triggers the file input.
  - **Close**: Closes the modal.
- Styled the modal using inline CSS for customization.
- Adjusted modal size to be compact for a better fit within the UI.

---

## ✅ Requirements Addressed

- Provide users with clear instructions on acceptable file formats and size limits.
- Ensure the modal is reusable and adheres to Bootstrap conventions.
- Maintain a clean and user-friendly interface.

---

## 📋 Acceptance Criteria

- [x] A Bootstrap Modal is present and opens when triggered.
- [x] The modal displays clear upload instructions.
- [x] Buttons in the modal function as expected:
  - "Upload Model" triggers file input and closes the modal.
  - "Close" simply closes the modal.
- [x] The modal design is compact and visually aligns with the rest of the Dashboard.

